### PR TITLE
web font loading enhancement 

### DIFF
--- a/css/font.css
+++ b/css/font.css
@@ -1,0 +1,23 @@
+
+
+@import url(https://fonts.googleapis.com/earlyaccess/notosanstc.css);
+
+body {
+    font-family: 'Noto Sans TC', "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+.navbar-custom {
+    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+.btn {
+    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+}

--- a/css/font.css
+++ b/css/font.css
@@ -1,5 +1,3 @@
-
-
 @import url(https://fonts.googleapis.com/earlyaccess/notosanstc.css);
 
 body {

--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -4,12 +4,11 @@
  * For details, see http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-@import url(https://fonts.googleapis.com/earlyaccess/notosanstc.css);
 
 body {
     width: 100%;
     height: 100%;
-    font-family: 'Noto Sans TC', "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     color: #000;
     background-color: #fff;
 }
@@ -27,7 +26,7 @@ h5,
 h6 {
     margin: 0 0 35px;
     text-transform: uppercase;
-    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 700;
     letter-spacing: 1px;
 }
@@ -67,7 +66,7 @@ a:focus {
     margin-bottom: 0;
     border-bottom: 1px solid rgba(255,255,255,.3);
     text-transform: uppercase;
-    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
     background-color: #0B62BD;
 }
 
@@ -328,7 +327,7 @@ a:focus {
 .btn {
     border-radius: 0;
     text-transform: uppercase;
-    font-family: 'Noto Sans TC', Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 400;
     -webkit-transition: all .3s ease-in-out;
     -moz-transition: all .3s ease-in-out;

--- a/index.html
+++ b/index.html
@@ -343,6 +343,9 @@
 
     <script src="js/formUtility.js"></script>
 
+    <!-- font CSS -->
+    <link href="css/font.css" rel="newer stylesheet">
+
 </body>
 
 </html>

--- a/show.html
+++ b/show.html
@@ -181,6 +181,8 @@
     <script src="js/show_workings.js"></script>
     <script src="js/show_by_job.js"></script>
 
+    <!-- font CSS -->
+    <link href="css/font.css" rel="newer stylesheet">
 
 </body>
 


### PR DESCRIPTION
move font loading css to the tail of body, not in header, because loading css will block browser

reference: 
https://www.keycdn.com/blog/web-font-performance/
