### PR TITLE
fix show uneccessary message when fb-login

### DIFF
--- a/js/grayscale.js
+++ b/js/grayscale.js
@@ -75,7 +75,6 @@ function statusChangeCallback(response) {
             submitForm();    
         }
         else{
-            showAlert(msg);
         }
         
         


### PR DESCRIPTION
fix show uneccessary message when fb-login
抱歉很多次PR阿，我這邊local端真的無法測
