### PR TITLE
Tweak query page

### DIFF
--- a/show.html
+++ b/show.html
@@ -101,17 +101,17 @@
                 <h3 style="margin-bottom:10px"><a :href="'#/company/' + company._id.name">{{ company._id.name }}</a></h3>
                 <table class="table">
                     <thead>
-                        <tr>
-                            <th>職稱</th>
-                            <th>平均週工時</th>
-                            <th>資料數量</th>
+                        <tr class="row">
+                            <th class="col-xs-5">職稱</th>
+                            <th class="col-xs-4">平均週工時</th>
+                            <th class="col-xs-3">資料數量</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <tr v-for="jobs in company.job_titles">
-                            <td>{{ jobs._id }}</td>
-                            <td>{{ jobs.average_week_work_time }}</td>
-                            <td>{{ jobs.count }}</td>
+                        <tr v-for="jobs in company.job_titles" class="row">
+                            <td class="col-xs-5">{{ jobs._id }}</td>
+                            <td class="col-xs-4">{{ jobs.average_week_work_time }}</td>
+                            <td class="col-xs-3">{{ jobs.count }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/show.html
+++ b/show.html
@@ -103,7 +103,7 @@
                     <thead>
                         <tr class="row">
                             <th class="col-xs-5">職稱</th>
-                            <th class="col-xs-4">平均週工時</th>
+                            <th class="col-xs-4">最近一週工時平均</th>
                             <th class="col-xs-3">資料數量</th>
                         </tr>
                     </thead>

--- a/show.html
+++ b/show.html
@@ -97,8 +97,8 @@
             </div>
         </div>
         <div class="row data-section-row" style="position: relative;">
-            <div class="col-md-12" v-for="company in companies">
-                <h3><a :href="'#/company/' + company._id.name">{{ company._id.name }}</a></h3>
+            <div class="col-md-12" v-for="company in companies" style="margin-bottom:20px">
+                <h3 style="margin-bottom:10px"><a :href="'#/company/' + company._id.name">{{ company._id.name }}</a></h3>
                 <table class="table">
                     <thead>
                         <tr>


### PR DESCRIPTION
做了三件事:
1. change margin of h3 and table: 讓公司名稱跟表格近一點，才不會搞混。
然後，我認為現階段也許沒有一致的準則，但可以先這樣改就好，之後UI重新設計再一併修正。
2. using grid system to normalize table width
3. 改字: "每週平均工時" -> "最近一週工時平均"

電腦上:　
![01](https://cloud.githubusercontent.com/assets/3805975/17316362/d4b5102a-58a5-11e6-8ed4-c2a1bfc8a9ae.PNG)

模擬手機上(iphone 5):
![02](https://cloud.githubusercontent.com/assets/3805975/17316361/d4b4fc70-58a5-11e6-88fe-113eba47f982.PNG)
