### PR TITLE
Add default autocomplete

### DIFF
--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -306,9 +306,6 @@ const statusChangeCallback = (response) => {
  * Autocomplete Part
  */
 $(function(){
-    const $job_title = $("#form-job-title");
-    const $company_query = $("#form-company-query");
-
     // default autocomplete:
     // fetch the newest job titles and company names
     var default_job_titles = [];
@@ -345,6 +342,10 @@ $(function(){
         if(item.disabled) li.addClass("ui-state-disabled");
         return li.appendTo(ul);
     };
+
+    // autocomplete
+    const $job_title = $("#form-job-title");
+    const $company_query = $("#form-company-query");
 
     $job_title.autocomplete({
         source: function (request, response) {

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -324,7 +324,7 @@ $(function(){
             Array.from(new Set(
                 $.map(res.workings, (item,i)=>({
                     "value": item.company.name,
-                    "id": item.company.id,
+                    "company_id": item.company.id,
                 })).filter( item=>item.id!==undefined )
             )).slice(0,4);
     });

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -308,22 +308,21 @@ const statusChangeCallback = (response) => {
 $(function(){
     const $job_title = $("#form-job-title");
     const $company_query = $("#form-company-query");
-    var default_job_title = [];
-    var default_num = 8;
+    var default_job_titles = [];
     $.ajax({
         url: WTS.constants.backendURL + 'workings/latest',
         dataType:"json",
     }).done(function(res){
-        default_job_title =
+        default_job_titles =
             Array.from(new Set(
                 $.map(res.workings, (item,i)=>{ return item.job_title; })
-            )).slice(0,default_num);
+            )).slice(0,8);
     });
     $job_title.autocomplete({
         source: function (request, response) {
             $job_title.trigger('autocomplete-search', request.term);
-            if(request.term==""){
-                response(default_job_title);
+            if(request.term.length==0){
+                response(default_job_titles);
                 return;
             }
             //var legend = {"id":"","value":"搜尋 '"+request.term+"'..."};
@@ -361,17 +360,30 @@ $(function(){
         */
     }).focus(function() {
         $(this).autocomplete("search",$(this).val());
-    }).data("ui-autocomplete")._renderItem = function(ul,item){
+    })/*.data("ui-autocomplete")._renderItem = function(ul,item){
         var li = $("<li>").append($("<div>").text(item.label));
         if(item.id=="") li.addClass("ui-state-disabled");
         return li.appendTo(ul);
     };
+    */
 
-    var default_job_title = [];
-    var default_num = 8;
+    var default_company_names = [];
+    $.ajax({
+        url: WTS.constants.backendURL + 'workings/latest',
+        dataType:"json",
+    }).done(function(res){
+        default_company_names =
+            Array.from(new Set(
+                $.map(res.workings, (item,i)=>{ return item.company.name; })
+            )).slice(0,8);
+    });
     $("#form-company-query").autocomplete({
         source: function (request, response) {
             $company_query.trigger('autocomplete-search', request.term);
+            if(request.term.length<2){
+                response(default_company_names);
+                return;
+            }
 
             $.ajax({
                 url: WTS.constants.backendURL + 'companies/search',
@@ -388,12 +400,14 @@ $(function(){
                 response([]);
             });
         },
-        minLength: 2,
+        minLength: 0,
         select: function(event, ui){
             $company_query.trigger('autocomplete-select', ui.item.company_id);
             $("#form-company-id").val(ui.item.company_id);
         },
-    });
+    }).focus(function() {
+        $(this).autocomplete("search",$(this).val());
+    })
 });
 
 /*

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -318,11 +318,11 @@ $(function(){
     }).done(function(res){
         default_job_titles =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>{ return item.job_title; })
+                $.map(res.workings, (item,i)=>item.job_title)
             )).slice(0,8);
         default_company_names =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>{ return item.company.name; })
+                $.map(res.workings, (item,i)=>item.company.name)
             )).slice(0,8);
     });
 
@@ -363,10 +363,10 @@ $(function(){
 
         // prevent disabled options from keyboard choosing
         focus: function(event, ui){
-            var curr = $(event.currentTarget).find('.ui-state-active');
-            if(curr.parent().hasClass('ui-state-disabled')){
+            var $active_item = $(event.$active_itementTarget).find('.ui-state-active');
+            if($active_item.parent().hasClass('ui-state-disabled')){
                 event.preventDefault();
-                curr.parent().siblings().first().children('div').mouseenter();  
+                $active_item.parent().siblings().first().children('div').mouseenter();  
             }
         }
     }).focus(function() {
@@ -412,17 +412,22 @@ $(function(){
         
         // prevent disabled options from keyboard choosing
         focus: function(event, ui){
-            var curr = $(event.currentTarget).find('.ui-state-active');
-            if(curr.parent().hasClass('ui-state-disabled')){
+            var $active_item = $(event.$active_itementTarget).find('.ui-state-active');
+            if($active_item.parent().hasClass('ui-state-disabled')){
                 event.preventDefault();
-                curr.parent().siblings().first().children('div').mouseenter();  
+                $active_item.parent().siblings().first().children('div').mouseenter();  
             }
         }
     }).focus(function() {
+        // trigger auto-complete list on focus
         $(this).autocomplete("search",$(this).val());
     }).data("ui-autocomplete")._renderItem = function(ul,item){
+        // render each item in ui.content as a <li> element
         var li = $("<li>").append($("<div>").text(item.label));
+        
+        // put .ui-state-disabled on disabled items (e.g. 最近被填寫的公司)
         if(item.disabled) li.addClass("ui-state-disabled");
+        
         return li.appendTo(ul);
     };
 });

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -308,36 +308,41 @@ const statusChangeCallback = (response) => {
 $(function(){
     // default autocomplete:
     // fetch the newest job titles and company names
-    var default_job_titles = [];
-    var default_company_names = [];
+    let default_job_titles = [];
+    let default_company_names = [];
     $.ajax({
         url: WTS.constants.backendURL + 'workings/latest',
         dataType:"json",
     }).done(function(res){
         default_job_titles =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>item.job_title)
-            )).slice(0,8);
+                $.map(res.workings, (item,i)=>({
+                    "value": item.job_title,
+                }))
+            )).slice(0,4);
         default_company_names =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>item.company.name)
-            )).slice(0,8);
+                $.map(res.workings, (item,i)=>({
+                    "value": item.company.name,
+                    "id": item.company.id,
+                })).filter( item=>item.id!==undefined )
+            )).slice(0,4);
     });
-    var default_search = function() {
+    const default_search = function() {
         $(this).autocomplete("search",$(this).val());
     };
 
     // prevent disabled options from keyboard choosing
-    var focus_prevent_disabled_options = function(event, ui){
-        var $active_item = $(event.currentTarget).find('.ui-state-active');
+    const focus_prevent_disabled_options = function(event, ui){
+        let $active_item = $(event.currentTarget).find('.ui-state-active');
         if($active_item.parent().hasClass('ui-state-disabled')){
             event.preventDefault();
             $active_item.parent().siblings().first().children('div').mouseenter();  
         }
     }
     // render each item in ui.content as a <li> element
-    var renderDisabledItem = function(ul,item){
-        var li = $("<li>").append($("<div>").text(item.label));
+    const renderDisabledItem = function(ul,item){
+        let li = $("<li>").append($("<div>").text(item.label));
         // put .ui-state-disabled on disabled items (e.g. 最近被填寫的公司)
         if(item.disabled) li.addClass("ui-state-disabled");
         return li.appendTo(ul);
@@ -353,9 +358,12 @@ $(function(){
 
             // show some list when focusing on an empty input
             if(request.term.length==0){
-                response(["最近被填寫的職位"].concat(default_job_titles).map(function(v,i){
-                    return {"value":v, disabled:i==0};
-                }));
+                response([{
+                    value:"最近被填寫的職位",
+                    disabled:true,
+                }].concat(
+                    default_job_titles.map(v=>{ v.disabled=false; return v; })
+                ));
                 return;
             }
 
@@ -391,9 +399,12 @@ $(function(){
             
             // show some list when focusing on an empty input
             if(request.term.length<2){
-                response(["最近被填寫的公司"].concat(default_company_names).map(function(v,i){
-                    return {"value":v, disabled:i==0};
-                }));
+                response([{
+                    value:"最近被填寫的公司",
+                    disabled:true,
+                }].concat(
+                    default_company_names.map(v=>{ v.disabled = false; return v })
+                ));
                 return;
             }
 

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -309,6 +309,7 @@ $(function(){
     const $job_title = $("#form-job-title");
     const $company_query = $("#form-company-query");
 
+    // default autocomplete:
     // fetch the newest job titles and company names
     var default_job_titles = [];
     var default_company_names = [];
@@ -318,13 +319,32 @@ $(function(){
     }).done(function(res){
         default_job_titles =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>{ return item.job_title; })
+                $.map(res.workings, (item,i)=>item.job_title)
             )).slice(0,8);
         default_company_names =
             Array.from(new Set(
-                $.map(res.workings, (item,i)=>{ return item.company.name; })
+                $.map(res.workings, (item,i)=>item.company.name)
             )).slice(0,8);
     });
+    var default_search = function() {
+        $(this).autocomplete("search",$(this).val());
+    };
+
+    // prevent disabled options from keyboard choosing
+    var focus_prevent_disabled_options = function(event, ui){
+        var $active_item = $(event.currentTarget).find('.ui-state-active');
+        if($active_item.parent().hasClass('ui-state-disabled')){
+            event.preventDefault();
+            $active_item.parent().siblings().first().children('div').mouseenter();  
+        }
+    }
+    // render each item in ui.content as a <li> element
+    var renderDisabledItem = function(ul,item){
+        var li = $("<li>").append($("<div>").text(item.label));
+        // put .ui-state-disabled on disabled items (e.g. 最近被填寫的公司)
+        if(item.disabled) li.addClass("ui-state-disabled");
+        return li.appendTo(ul);
+    };
 
     $job_title.autocomplete({
         source: function (request, response) {
@@ -360,22 +380,9 @@ $(function(){
         select: function(event, ui){
             $job_title.trigger('autocomplete-select', ui.item.label);
         },
+        focus: focus_prevent_disabled_options,
 
-        // prevent disabled options from keyboard choosing
-        focus: function(event, ui){
-            var curr = $(event.currentTarget).find('.ui-state-active');
-            if(curr.parent().hasClass('ui-state-disabled')){
-                event.preventDefault();
-                curr.parent().siblings().first().children('div').mouseenter();  
-            }
-        }
-    }).focus(function() {
-        $(this).autocomplete("search",$(this).val());
-    }).data("ui-autocomplete")._renderItem = function(ul,item){
-        var li = $("<li>").append($("<div>").text(item.label));
-        if(item.disabled) li.addClass("ui-state-disabled");
-        return li.appendTo(ul);
-    };
+    }).focus(default_search).data("ui-autocomplete")._renderItem = renderDisabledItem;
 
     $("#form-company-query").autocomplete({
         source: function (request, response) {
@@ -409,22 +416,9 @@ $(function(){
             $company_query.trigger('autocomplete-select', ui.item.company_id);
             $("#form-company-id").val(ui.item.company_id);
         },
-        
-        // prevent disabled options from keyboard choosing
-        focus: function(event, ui){
-            var curr = $(event.currentTarget).find('.ui-state-active');
-            if(curr.parent().hasClass('ui-state-disabled')){
-                event.preventDefault();
-                curr.parent().siblings().first().children('div').mouseenter();  
-            }
-        }
-    }).focus(function() {
-        $(this).autocomplete("search",$(this).val());
-    }).data("ui-autocomplete")._renderItem = function(ul,item){
-        var li = $("<li>").append($("<div>").text(item.label));
-        if(item.disabled) li.addClass("ui-state-disabled");
-        return li.appendTo(ul);
-    };
+        focus:focus_prevent_disabled_options,
+
+    }).focus(default_search).data("ui-autocomplete")._renderItem = renderDisabledItem;
 });
 
 /*

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -308,10 +308,26 @@ const statusChangeCallback = (response) => {
 $(function(){
     const $job_title = $("#form-job-title");
     const $company_query = $("#form-company-query");
+    var default_job_title = [];
+    var default_num = 8;
+    $.ajax({
+        url: WTS.constants.backendURL + 'workings/latest',
+        dataType:"json",
+    }).done(function(res){
+        default_job_title =
+            Array.from(new Set(
+                $.map(res.workings, (item,i)=>{ return item.job_title; })
+            )).slice(0,default_num);
+    });
     $job_title.autocomplete({
         source: function (request, response) {
             $job_title.trigger('autocomplete-search', request.term);
-
+            if(request.term==""){
+                response(default_job_title);
+                return;
+            }
+            //var legend = {"id":"","value":"搜尋 '"+request.term+"'..."};
+            //response([legend]);
             $.ajax({
                 url: WTS.constants.backendURL + 'jobs/search',
                 data: {
@@ -325,16 +341,34 @@ $(function(){
                         id: item._id,
                     };
                 });
+                //nameList.splice(0,0,legend);
                 response(nameList);
             }).fail((jqXHR, textStatus) => {
                 response([]);
             });
         },
+        minLength:0,
         select: function(event, ui){
             $job_title.trigger('autocomplete-select', ui.item.label);
         },
-    });
+        /*focus: function(event, ui){
+            var curr = $(event.currentTarget).find('.ui-state-active');
+            if(curr.parent().hasClass('ui-state-disabled')){
+                event.preventDefault();
+                curr.parent().siblings().first().children('div').mouseenter();  
+            }
+        }
+        */
+    }).focus(function() {
+        $(this).autocomplete("search",$(this).val());
+    }).data("ui-autocomplete")._renderItem = function(ul,item){
+        var li = $("<li>").append($("<div>").text(item.label));
+        if(item.id=="") li.addClass("ui-state-disabled");
+        return li.appendTo(ul);
+    };
 
+    var default_job_title = [];
+    var default_num = 8;
     $("#form-company-query").autocomplete({
         source: function (request, response) {
             $company_query.trigger('autocomplete-search', request.term);


### PR DESCRIPTION
When user focuses on `input#job_title` and `input#company_query` before typing any characters, the list of the top _n_ recently provided job_title/company_query are shown to the user.

This hints that the input fields have auto-completion-like function.

to fix #305 
