### PR TITLE
GA migration for 工時填寫頁

### DIFF
--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -529,5 +529,3 @@ $company_query.on('autocomplete-search', (query) => {
 $company_query.on('autocomplete-search', (selected) => {
     ga && ga('send', 'event', 'LANDING_PAGE', 'company-query-autocomplete-select', selected);
 });
-
-

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -462,7 +462,7 @@ $work_form.one('beginWriting', (e) => {
   ga && ga('send', 'timing', 'LANDING_PAGE', 'form-begin-writing', formBeginTime);
 });
 
-$work_form.on('submited', (e, result) => {
+$work_form.on('submitted', (e, result) => {
   if(!result.error){
     if(!hasSendedFormWritingTime){
       formSubmittedTime = performance.now();

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -479,6 +479,17 @@ $work_form.on("submit", (e) => {
   ga && ga('send', 'event', 'LANDING_PAGE', 'click-submit');
 });
 
+// tracking sharing button clicking
+const $fb_share_button = $("#fb-share-button");
+const $twitter_share_button = $("#twitter-share-button");
+
+$fb_share_button.on('click', (e) => {
+  ga && ga('send', 'event', 'LANDING_PAGE', 'click-fb-share');
+});
+$twitter_share_button.on('click', (e) => {
+  ga && ga('send', 'event', 'LANDING_PAGE', 'click-twitter-share');
+});
+
 const $job_title = $("#form-job-title");
 const $company_query = $("#form-company-query");
 
@@ -498,13 +509,4 @@ $company_query.on('autocomplete-search', (selected) => {
     ga && ga('send', 'event', 'LANDING_PAGE', 'company-query-autocomplete-select', selected);
 });
 
-const $fb_share_button = $("#fb-share-button");
-const $twitter_share_button = $("#twitter-share-button");
-
-$fb_share_button.on('click', (e) => {
-  ga && ga('send', 'event', 'LANDING_PAGE', 'click-fb-share');
-});
-$twitter_share_button.on('click', (e) => {
-  ga && ga('send', 'event', 'LANDING_PAGE', 'click-twitter-share');
-});
 

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -474,6 +474,11 @@ $work_form.on('submited', (e, result) => {
   }
 });
 
+// tracking submit button clicking
+$work_form.on("submit", (e) => {
+  ga && ga('send', 'event', 'LANDING_PAGE', 'click-submit');
+});
+
 const $job_title = $("#form-job-title");
 const $company_query = $("#form-company-query");
 

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -436,6 +436,44 @@ $(function(){
 /*
  * GA part
  */
+// Calculating form writing time
+let formBeginTime = null;
+let formSubmittedTime = null;
+let hasSendedFormWritingTime = false;
+$(function() {
+  (function() {
+    var isCalled = false;
+    function callback(e) {
+      if (isCalled) {
+        return;
+      }
+      isCalled = true;
+      $('#work-form').trigger('beginWriting');
+    }
+
+    $('#work-form input').on('focus', callback);
+    $('#work-form input').on('click', callback);
+    $('#work-form input[type=radio]').on('change', callback);
+  })();
+});
+
+$work_form.one('beginWriting', (e) => {
+  formBeginTime = performance.now();
+  ga && ga('send', 'timing', 'LANDING_PAGE', 'form-begin-writing', formBeginTime);
+});
+
+$work_form.on('submited', (e, result) => {
+  if(!result.error){
+    if(!hasSendedFormWritingTime){
+      formSubmittedTime = performance.now();
+      const elapsedTime = formSubmittedTime - formBeginTime;
+      ga && ga('send', 'timing', 'LANDING_PAGE', 'form-submitted', formSubmittedTime);
+      ga && ga('send', 'timing', 'LANDING_PAGE', 'form-writing', elapsedTime);
+      hasSendedFormWritingTime = true;
+    } 
+  }
+});
+
 const $job_title = $("#form-job-title");
 const $company_query = $("#form-company-query");
 
@@ -453,5 +491,15 @@ $company_query.on('autocomplete-search', (query) => {
 
 $company_query.on('autocomplete-search', (selected) => {
     ga && ga('send', 'event', 'LANDING_PAGE', 'company-query-autocomplete-select', selected);
+});
+
+const $fb_share_button = $("#fb-share-button");
+const $twitter_share_button = $("#twitter-share-button");
+
+$fb_share_button.on('click', (e) => {
+  ga && ga('send', 'event', 'LANDING_PAGE', 'click-fb-share');
+});
+$twitter_share_button.on('click', (e) => {
+  ga && ga('send', 'event', 'LANDING_PAGE', 'click-twitter-share');
 });
 

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -490,6 +490,27 @@ $twitter_share_button.on('click', (e) => {
   ga && ga('send', 'event', 'LANDING_PAGE', 'click-twitter-share');
 });
 
+// tracking form validation and upload status
+$work_form.on("submitted", (e, result) => {
+  if (result.error) {
+    if (result.type === "ValidationError") {
+      ga && ga('send', 'event', 'LANDING_PAGE', 'check-form-fail', result.error.message);
+    } else if (result.type === "AuthError") {
+      ga && ga('send', 'event', 'LANDING_PAGE', 'upload-fail', result.error.message);
+    } else if (result.type === "SendError") {
+      if (result.jqXHR.readyState === 0) {
+        ga && ga('send', 'event', 'LANDING_PAGE', 'upload-fail', 'readyState:' + result.jqXHR.readyState);
+      } else if (result.jqXHR.readyState === 4) {
+        ga && ga('send', 'event', 'LANDING_PAGE', 'upload-fail', result.jqXHR.responseJSON.message);
+      } else {
+        ga && ga('send', 'event', 'LANDING_PAGE', 'upload-fail', result.error.message);
+      }
+    }
+  } else {
+    ga && ga('send', 'event', 'LANDING_PAGE', 'upload-success');
+  }
+});
+
 const $job_title = $("#form-job-title");
 const $company_query = $("#form-company-query");
 

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -191,7 +191,7 @@ block content
 					h2(class="heading__heading") 分享此活動
 				div(class="share-buttons")
 					span(id="fb-share-button" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-facebook"><use xlink:href="#icon-facebook"></use></svg> facebook
-					span(id="twtter-share-button" onclick="window.open('https://twitter.com/home?status=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-twitter"><use xlink:href="#icon-twitter"></use></svg> twitter
+					span(id="twitter-share-button" onclick="window.open('https://twitter.com/home?status=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-twitter"><use xlink:href="#icon-twitter"></use></svg> twitter
 				div(class="like-fb-word")
 					span <a href="https://www.facebook.com/goodjob.life/">粉絲頁</a>按讚，隨時取得最新消息
 					span(class="fb-like" data-href="https://www.facebook.com/goodjob.life/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="true" data-share="false")

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -190,8 +190,8 @@ block content
 				div(class="heading")
 					h2(class="heading__heading") 分享此活動
 				div(class="share-buttons")
-					span(onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-facebook"><use xlink:href="#icon-facebook"></use></svg> facebook
-					span(onclick="window.open('https://twitter.com/home?status=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-twitter"><use xlink:href="#icon-twitter"></use></svg> twitter
+					span(id="fb-share-button" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-facebook"><use xlink:href="#icon-facebook"></use></svg> facebook
+					span(id="twtter-share-button" onclick="window.open('https://twitter.com/home?status=https%3A//worktime.goodjob.life/', 'newwindow', 'width=555, height=630'); return false;" class="share-buttons__item btn-white btn-m") <svg role="img" class="icon-twitter"><use xlink:href="#icon-twitter"></use></svg> twitter
 				div(class="like-fb-word")
 					span <a href="https://www.facebook.com/goodjob.life/">粉絲頁</a>按讚，隨時取得最新消息
 					span(class="fb-like" data-href="https://www.facebook.com/goodjob.life/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="true" data-share="false")


### PR DESCRIPTION
- [x] load GA script into landing page
- [x] Tracking submit button click event
  原本埋在index.html裡面，現在獨立出來寫在Js裡面。
- [x] Tracking uploading successful/failed event
- [x] Tracking checking form failed event
- [x] Tracking share button event 
  原本是: `click-fb-share-before-submit` & `click-fb-share-after-submit`
  現在改為: `click-fb-share`, `click-twitter-share`
- [ ] Tracking navigation bar click event  (尚未完成，因為會牽涉到另個page，打算另開PR)
- [x] Tracking autocomplete term (company name & job-title)
- [x] Tracking the time of writing a form #219 
  - [x] The time of start writing a form since page load
  - [x] The time span of writing a form
