### PR TITLE
move fb sdk async load out of _layout.pug to index.js

### DIFF
--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -276,6 +276,8 @@ $work_form.on("submitted", (e, result) => {
 /*
  * Facebook related
  */
+
+//define async function first
 window.fbAsyncInit = () => {
   const appId = (window.location.hostname === "localhost") ? "1750608541889151" : "1750216878594984";
   FB.init({
@@ -301,6 +303,16 @@ const statusChangeCallback = (response) => {
     document.querySelector(".btn-why-facebook-login").style.display = "";
   }
 };
+
+//execute async function to load fb sdk
+(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/zh_TW/sdk.js";
+  fjs.parentNode.insertBefore(js, fjs);
+})(document, 'script', 'facebook-jssdk');
+
 
 /*
  * Autocomplete Part

--- a/src/views/_layout.pug
+++ b/src/views/_layout.pug
@@ -34,14 +34,6 @@ html(lang="zh")
 
 	body(class="site "+bodyClass)
 		div(id="fb-root")
-		script.
-			(function(d, s, id) {
-					var js, fjs = d.getElementsByTagName(s)[0];
-					if (d.getElementById(id)) return;
-					js = d.createElement(s); js.id = id;
-					js.src = "//connect.facebook.net/zh_TW/sdk.js";
-					fjs.parentNode.insertBefore(js, fjs);
-			})(document, 'script', 'facebook-jssdk');
 		div(style="display:none")
 			include ./partials/svg-symbols.svg
 		include ./partials/_header.pug


### PR DESCRIPTION
幾個key point:
1.

```
FB.getLoginStatus((response) => {
    statusChangeCallback(response);
  });
```

這一段必須要在 `window.fbAsyncInit` 裡面。應該說FB這個變數就是在`window.fbAsyncInit`裡面。

2.
`window.fbAsyncInit` 要先宣告，再去執行

```
(function(d, s, id) {
  var js, fjs = d.getElementsByTagName(s)[0];
  if (d.getElementById(id)) return;
  js = d.createElement(s); js.id = id;
  js.src = "//connect.facebook.net/zh_TW/sdk.js";
  fjs.parentNode.insertBefore(js, fjs);
})(document, 'script', 'facebook-jssdk');
```

所以我把這段拉回index.js了，而且是在`window.fbAsyncInit`後面。

ref: #337 
