### PR TITLE
新增Routes 

### DIFF
--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -323,7 +323,7 @@ Vue.filter('salary_type_string', value => {
   return "";
 });
 
-//Attribution: http://stackoverflow.com/a/29249277/4844397  
+//Attribution: http://stackoverflow.com/a/29249277/4844397
 //http://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
 Vue.filter('formatted_wage_string', value => {
     if(typeof value == 'number') return parseFloat(value).toFixed(2).replace(/\.?0*$/g, '').replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -455,12 +455,66 @@ const router = Router({
       });
     },
   },
+  "/job-title/:job_title/sort/work-time-asc": {
+    on: (job_title) => {
+      showjs_store.changeViewState("searchAndGroupByJobTitle", {
+        job_title: decodeURIComponent(job_title),
+        group_sort_by: "week_work_time",
+        order: "ascending",
+      });
+    },
+  },
+  "/job-title/:job_title/salary-dashboard": {
+    on: (job_title) => {
+      showjs_store.changeViewState("searchAndGroupByJobTitle", {
+        job_title: decodeURIComponent(job_title),
+        group_sort_by: "estimated_hourly_wage",
+        order: "descending",
+      });
+    },
+  },
+  "/job-title/:job_title/sort/salary-asc": {
+    on: (job_title) => {
+      showjs_store.changeViewState("searchAndGroupByJobTitle", {
+        job_title: decodeURIComponent(job_title),
+        group_sort_by: "estimated_hourly_wage",
+        order: "ascending",
+      });
+    },
+  },
   "/company/:company/work-time-dashboard": {
     on: (company) => {
       showjs_store.changeViewState("searchAndGroupByCompany", {
         company: decodeURIComponent(company),
         group_sort_by: "week_work_time",
         order: "descending",
+      });
+    },
+  },
+  "/company/:company/sort/work-time-asc": {
+    on: (company) => {
+      showjs_store.changeViewState("searchAndGroupByCompany", {
+        company: decodeURIComponent(company),
+        group_sort_by: "week_work_time",
+        order: "ascending",
+      });
+    },
+  },
+  "/company/:company/salary-dashboard": {
+    on: (company) => {
+      showjs_store.changeViewState("searchAndGroupByCompany", {
+        company: decodeURIComponent(company),
+        group_sort_by: "estimated_hourly_wage",
+        order: "descending",
+      });
+    },
+  },
+  "/company/:company/sort/salary-asc": {
+    on: (company) => {
+      showjs_store.changeViewState("searchAndGroupByCompany", {
+        company: decodeURIComponent(company),
+        group_sort_by: "estimated_hourly_wage",
+        order: "ascending",
       });
     },
   },


### PR DESCRIPTION
總共有以下的routes: 
單筆資訊:
1. `/latest` (以時間排序由新到舊)
2. `/sort/time-asc` (以時間排序由舊到新)
3. `/work-time-dashboard` (以週工時排序由大到小，也就是工時排行)
4. `/sort/work-time-asc` (以週工時排序由小到大)
5. `/salary-dashboard` (以估計時薪排序由大到小，也就是時薪排行)
6. `/sort/salary-asc` (以估計時薪排序由小到大)

以職稱查詢:
1. `/job-title/:job_title/work-time-dashboard`  (以週工時排序由大到小)
2. `/job-title/:job_title/sort/work-time-asc` (以週工時排序由小到大)
3. `/job-title/:job_title/salary-dashboard` (以估計時薪排序由大到小)
4. `/job-title/:job_title/sort/salary-asc` (以估計時薪排序由小到大)

以公司查詢:
1. `/company/:company/work-time-dashboard`  (以週工時排序由大到小)
2. `/company/:company/sort/work-time-asc` (以週工時排序由小到大)
3. `/company/:company/salary-dashboard` (以估計時薪排序由大到小)
4. `/company/:company/sort/salary-asc` (以估計時薪排序由小到大)

[ref doc](https://docs.google.com/document/d/14DdYrWTYJzr0FN3r7Myvs-9ka-Se1669QEFGEonzXC4/edit?usp=sharing)
