### PR TITLE
Change order to group_sort_order

### DIFF
--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -240,9 +240,9 @@ const searchAndGroupByJobTitle = Vue.extend({
       this.is_loading = true;
 
       const group_sort_by = searchResultSort.group_sort_by;
-      const order = searchResultSort.order;
+      const group_sort_order = searchResultSort.order;
 
-      this.getData(job_title_keyword, group_sort_by, order).then(res => {
+      this.getData(job_title_keyword, group_sort_by, group_sort_order).then(res => {
         this.data = res.data;
       }, err => {
         this.data = [];
@@ -251,12 +251,12 @@ const searchAndGroupByJobTitle = Vue.extend({
         this.$emit('data_loaded');
       });
     },
-    getData: function(job_title, group_sort_by, order) {
+    getData: function(job_title, group_sort_by, group_sort_order {
       const opt = {
         params: {
           job_title,
           group_sort_by,
-          order,
+          group_sort_order,
           access_token: typeof FB !== 'undefined' ? FB.getAuthResponse().accessToken : undefined,
         },
       };
@@ -338,9 +338,9 @@ const searchAndGroupByCompany = Vue.extend({
       this.is_loading = true;
 
       const group_sort_by = searchResultSort.group_sort_by;
-      const order = searchResultSort.order;
+      const group_sort_order = searchResultSort.order;
 
-      this.getData(company_keyword, group_sort_by, order).then(res => {
+      this.getData(company_keyword, group_sort_by, group_sort_order).then(res => {
         this.data = res.data;
       }, err => {
         this.data = [];
@@ -350,12 +350,12 @@ const searchAndGroupByCompany = Vue.extend({
         this.$emit('data_loaded');
       });
     },
-    getData: function(company, group_sort_by, order) {
+    getData: function(company, group_sort_by, group_sort_order) {
       const opt = {
         params: {
           company,
           group_sort_by,
-          order,
+          group_sort_order,
           access_token: typeof FB !== 'undefined' ? FB.getAuthResponse().accessToken : undefined,
         },
       };

--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -251,7 +251,7 @@ const searchAndGroupByJobTitle = Vue.extend({
         this.$emit('data_loaded');
       });
     },
-    getData: function(job_title, group_sort_by, group_sort_order {
+    getData: function(job_title, group_sort_by, group_sort_order) {
       const opt = {
         params: {
           job_title,


### PR DESCRIPTION
從 工時排行榜 上面可以發現排序是透過 order 欄位送出，
導致 API Server 以預設的參數返回（group_sort_order=descending）

此版本影響 3.x

由於只有用到兩次這個 api，所以直接 api 文件修正