### PR TITLE
填薪資時的輔助字功能

### DIFF
--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -147,6 +147,73 @@ const appendJobExperienceTime = () => {
 };
 appendJobExperienceTime();
 
+/**
+ * Salary hint text
+ */
+
+//convert positive integer to [xxxx億][xxxx萬][xxxx]元 format
+const numToChineseReadableString = (num) => {
+  if (typeof num !== 'number') {
+    return;
+  }
+  if (num <= 0 || !Number.isInteger(num)) {
+    return;
+  }
+  const base = [1, 10000, 100000000];
+  const baseWord = ['', '萬', '億'];
+  let str = '';
+  let c;
+  for(let i = base.length; i >= 0; i--){
+    if (num >= base[i]) {
+      c = Math.floor(num / base[i]);
+      num = num - c * base[i];
+      str = str + `${c}${baseWord[i]}`;
+    }
+  }
+  return str + '元';
+}
+
+const shouldShowSalaryWarning = (salary_type, salary_amount) => {
+  if (typeof salary_amount !== 'number') {
+    return;
+  }
+  const ranges = {
+    'hour': [100, 500],
+    'day': [800, 4000],
+    'month': [20000, 100000],  //2萬, 10萬
+    'year': [200000, 1000000],  //20萬, 100萬
+  }
+  if (!salary_type in ranges){
+    return;
+  }
+  if (salary_amount <= ranges[salary_type][0] || salary_amount >= ranges[salary_type][1]){
+    return true;
+  } else {
+    return false;
+  }
+}
+
+const salaryHintHtml = (salary_type, salary_amount) => {
+  const readableStr = numToChineseReadableString(salary_amount);
+  const showWarning = shouldShowSalaryWarning(salary_type, salary_amount);
+  if (typeof readableStr === 'undefined' || typeof showWarning === 'undefined') {
+    return;
+  }
+  const salaryTypeWord = {
+    'hour': '時薪',
+    'day': '日薪',
+    'month': '月薪',
+    'year': '年薪',
+  }
+  let hint = `${salaryTypeWord[salary_type]} ${readableStr}`;
+
+  if (showWarning) {
+    return `<span class="form-warning-text">${hint}，確定嗎？</span>`;
+  } else {
+    return `<span>${hint}</span>`;
+  }
+}
+
 /*
  * Form Submit Controller
  */

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -193,7 +193,7 @@ const shouldShowSalaryWarning = (salary_type, salary_amount) => {
   }
 }
 
-const salaryHintHtml = (salary_type, salary_amount) => {
+const salaryHint = (salary_type, salary_amount) => {
   const readableStr = numToChineseReadableString(salary_amount);
   const showWarning = shouldShowSalaryWarning(salary_type, salary_amount);
   if (typeof readableStr === 'undefined' || typeof showWarning === 'undefined') {
@@ -205,13 +205,8 @@ const salaryHintHtml = (salary_type, salary_amount) => {
     'month': '月薪',
     'year': '年薪',
   }
-  let hint = `${salaryTypeWord[salary_type]} ${readableStr}`;
-
-  if (showWarning) {
-    return `<span class="form-warning-text">${hint}，確定嗎？</span>`;
-  } else {
-    return `<span>${hint}</span>`;
-  }
+  const hint = `${salaryTypeWord[salary_type]} ${readableStr}`;
+  return {showWarning, hint};
 }
 
 /*


### PR DESCRIPTION
issue: #488 

分為三個部分：
1. 將薪資的數字轉為 [xxxx億][xxxx萬][xxxx]元 這樣的格式。 與原本issue提的並不相同，原本是以千、萬、千萬為單位，但經實測發現，千這個單位其實沒有必要，反而增加閱讀的困難。 
e.g. `2萬2200元` 的可讀性其實比 `2萬2千200元` 高。  

2. 根據salary_type & salary_amount，回傳是否要顯示警告訊息（意即加上 `，確定嗎？`，並顯示紅字），回傳值為 true, false。範圍是根據issue最後的提案：
```
時薪範圍： 100 ~ 500
日薪範圍： 800 ~ 4,000
月薪範圍：20,000 ~ 100,000
年薪範圍：200,000 ~ 1,000,000
```
範圍外 (大於等於max, 小於等於min)，就會回傳true

3. salaryHint 函數會回傳兩個值 {showWarning, hint}，`showWarning`是要不要顯示為紅字，`hint`則是提示的訊息。

這個pr 完成後，仍需要Tin協助將輔助字放到表單中

