### PR TITLE
預設前 1 % 為隱藏功能

### DIFF
--- a/src/css/components/search/_search-result.pcss
+++ b/src/css/components/search/_search-result.pcss
@@ -96,3 +96,18 @@
     }
   }
 }
+
+.extreme-hint {
+  color: #333333;
+  font-size: 18px;
+  line-height: 29px;
+  margin: 10px 0px;
+  text-align: center;
+}
+
+.extreme-button {
+  color: #02309E;
+  font-size: 16px;
+  line-height: 24px;
+  text-align: center;
+}

--- a/src/css/components/table/_latest-table.pcss
+++ b/src/css/components/table/_latest-table.pcss
@@ -22,3 +22,7 @@
     width: 10%;
   }
 }
+
+.tbody-extreme-hint {
+  background: #f9f9f9;
+}

--- a/src/css/components/table/_rwd-table.pcss
+++ b/src/css/components/table/_rwd-table.pcss
@@ -19,7 +19,7 @@
   &.is-disabled {
     td {
       pointer-events: none;
-    }  
+    }
   }
   th {
     @mixin table-th;
@@ -47,7 +47,7 @@
       width: 100%;
       padding: 10px 20px;
     }
-    &:before {
+    &:not(.td-extreme-hint):before {
 			@media (max-width: $below-small) {
 				content: attr(data-th);
         flex: 0 0 100px;

--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -81,7 +81,7 @@ const timeAndSalary = Vue.extend({
           order: this.share.view_params.order,
           page,
           limit,
-          skip: this.share.view_params.sort_by !== 'created_at',
+          skip: (this.share.view_params.sort_by !== 'created_at').toString(),
         },
       };
 

--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -119,10 +119,6 @@ const timeAndSalary = Vue.extend({
         if (this.share.view_params.sort_by === 'created_at') {
           return;
         }
-        this.search_result_sort = {
-          sort_by: this.share.view_params.sort_by,
-          order: this.share.view_params.order,
-        };
 
         this.loadExtremeTimeAndSalary();
       }

--- a/src/js/main/show.js
+++ b/src/js/main/show.js
@@ -48,22 +48,6 @@ const timeAndSalary = Vue.extend({
     };
   },
   events: {
-    toggle_extreme_time_and_salary: function() {
-      if (this.show_extreme) {
-        this.show_extreme = false;
-      }
-      else {
-        if (this.share.view_params.sort_by === 'created_at') {
-          return;
-        }
-        this.search_result_sort = {
-          sort_by: this.share.view_params.sort_by,
-          order: this.share.view_params.order,
-        };
-
-        this.loadExtremeTimeAndSalary();
-      }
-    },
     load_time_and_salary: function() {
       this.search_result_sort = {
         sort_by: this.share.view_params.sort_by,
@@ -126,6 +110,22 @@ const timeAndSalary = Vue.extend({
         this.is_loading = false;
         this.current_page;
       });
+    },
+    toggleExtremeTimeAndSalary: function() {
+      if (this.show_extreme) {
+        this.show_extreme = false;
+      }
+      else {
+        if (this.share.view_params.sort_by === 'created_at') {
+          return;
+        }
+        this.search_result_sort = {
+          sort_by: this.share.view_params.sort_by,
+          order: this.share.view_params.order,
+        };
+
+        this.loadExtremeTimeAndSalary();
+      }
     },
     loadExtremeTimeAndSalary: function() {
       this.extreme_is_loading = true;
@@ -875,15 +875,6 @@ $(window).on('scroll', function() {
       app.$broadcast("scroll_bottom_reach");
     }
   }
-});
-
-
-$(document).ready(function() {
-  $("#show-extreme").on('click', function() {
-    if (app.currentView === TIME_AND_SALARY_VIEW) {
-      app.$broadcast("toggle_extreme_time_and_salary");
-    }
-  });
 });
 
 // wait the event trigger done

--- a/src/views/partials/_show_time_and_salary.pug
+++ b/src/views/partials/_show_time_and_salary.pug
@@ -60,7 +60,7 @@ section(class="search-result")
 						span(class="rwd-td")
 							span(class="data-time") {{w.data_time.year}}.{{w.data_time.month | two_digit_month}}
 		div(class="extreme-hint" v-show="search_result_sort.sort_by !== 'created_at'") {{ show_extreme | extreme_hint_text }}
-			button(id="show-extreme" class="extreme-button") {{ show_extreme | extreme_button_text }}
+			button(id="show-extreme" class="extreme-button" v-on:click="toggleExtremeTimeAndSalary") {{ show_extreme | extreme_button_text }}
 		table(class="rwd-table latest-table", :class="{ 'is-disabled':  !share.is_authed}")
 			tbody(id="tbody-latest-data")
 				tr(v-for="w in time_and_salary")

--- a/src/views/partials/_show_time_and_salary.pug
+++ b/src/views/partials/_show_time_and_salary.pug
@@ -24,6 +24,44 @@ section(class="search-result")
 						<div data-modal-id="info-salary" data-info-button>估計時薪</div>
 					th(class="col-data-time")
 						<div data-modal-id="info-time" data-info-button>參考時間</div>
+		table(v-if="show_extreme" class="rwd-table latest-table", :class="{ 'is-disabled':  !share.is_authed}")
+			tbody(id="tbody-one-percent-data")
+				tr(v-for="w in extreme_time_and_salary")
+					td(data-th="公司名稱")
+						span(class="rwd-td")
+							a(href="#/company/{{encodeURIComponent(w.company ? w.company.name : '')}}/work-time-dashboard") {{w.company ? w.company.name : ""}}
+					td(data-th="職稱 (廠區/門市/分公司)")
+						span(class="rwd-td")
+							span
+								a(href="#/job-title/{{encodeURIComponent(w.job_title)}}/work-time-dashboard") {{w.job_title}}
+							span(class="table-sector") {{w.sector}}
+					td(data-th="一週總工時")
+						span(class="rwd-td")
+							span(v-if="w.week_work_time")
+								span(class="table-time-bar" data-time="{{w.week_work_time}}" v-bind:style="{ width: w.week_work_time + 'px' }") {{w.week_work_time}}
+							span(v-else) -
+					td(data-th="加班頻率")
+						span(class="rwd-td")
+							span(v-if="w.overtime_frequency | overtime_frequency_string")
+								span(class="table-frequency-circle" data-frequency="{{w.overtime_frequency}}")
+								| {{w.overtime_frequency | overtime_frequency_string}}
+							span(v-else) -
+					td(data-th="薪資")
+						span(class="rwd-td align-right")
+							span(v-if="w.salary.amount | formatted_wage_string")
+								| {{w.salary.amount | formatted_wage_string}} / {{w.salary.type | salary_type_string}}
+							span(v-else) -
+					td(data-th="估計時薪")
+						span(class="rwd-td align-right")
+							span(v-if="w.estimated_hourly_wage | formatted_wage_string")
+								| {{w.estimated_hourly_wage | formatted_wage_string}} 元
+							span(v-else) -
+					td(data-th="參考時間")
+						span(class="rwd-td")
+							span(class="data-time") {{w.data_time.year}}.{{w.data_time.month | two_digit_month}}
+		div(class="extreme-hint" v-show="search_result_sort.sort_by !== 'created_at'") {{ show_extreme | extreme_hint_text }}
+			button(id="show-extreme" class="extreme-button") {{ show_extreme | extreme_button_text }}
+		table(class="rwd-table latest-table", :class="{ 'is-disabled':  !share.is_authed}")
 			tbody(id="tbody-latest-data")
 				tr(v-for="w in time_and_salary")
 					td(data-th="公司名稱")

--- a/src/views/partials/_show_time_and_salary.pug
+++ b/src/views/partials/_show_time_and_salary.pug
@@ -24,8 +24,7 @@ section(class="search-result")
 						<div data-modal-id="info-salary" data-info-button>估計時薪</div>
 					th(class="col-data-time")
 						<div data-modal-id="info-time" data-info-button>參考時間</div>
-		table(v-if="show_extreme" class="rwd-table latest-table", :class="{ 'is-disabled':  !share.is_authed}")
-			tbody(id="tbody-one-percent-data")
+			tbody(id="tbody-one-percent-data" v-if="show_extreme")
 				tr(v-for="w in extreme_time_and_salary")
 					td(data-th="公司名稱")
 						span(class="rwd-td")
@@ -59,9 +58,11 @@ section(class="search-result")
 					td(data-th="參考時間")
 						span(class="rwd-td")
 							span(class="data-time") {{w.data_time.year}}.{{w.data_time.month | two_digit_month}}
-		div(class="extreme-hint" v-show="search_result_sort.sort_by !== 'created_at'") {{ show_extreme | extreme_hint_text }}
-			button(id="show-extreme" class="extreme-button" v-on:click="toggleExtremeTimeAndSalary") {{ show_extreme | extreme_button_text }}
-		table(class="rwd-table latest-table", :class="{ 'is-disabled':  !share.is_authed}")
+			tbody(class="tbody-extreme-hint")
+				tr
+					td(colspan="7" class="td-extreme-hint")
+						div(class="extreme-hint" v-show="search_result_sort.sort_by !== 'created_at'") {{ show_extreme | extreme_hint_text }}
+							button(id="show-extreme" class="extreme-button" v-on:click="toggleExtremeTimeAndSalary") {{ show_extreme | extreme_button_text }}
 			tbody(id="tbody-latest-data")
 				tr(v-for="w in time_and_salary")
 					td(data-th="公司名稱")


### PR DESCRIPTION
測試網址：http://localhost:8080/time-and-salary.html

說明：
1. 目前只有"單筆"的薪資工時資料才有這個功能
2. 用 created_at 排序的話不會有這個功能
3. 嘗試點擊展開/隱藏、換排序方式，看有沒有問題

後端可以接：https://api-stage-v4.goodjob.life/workings 測試